### PR TITLE
Add uname()

### DIFF
--- a/lib/posix.dart
+++ b/lib/posix.dart
@@ -14,6 +14,7 @@ export 'src/stat/mode.dart';
 export 'src/stat/stat.dart';
 export 'src/string/string.dart';
 export 'src/sysinfo.dart';
+export 'src/uname/uname.dart';
 export 'src/unistd/errno.dart';
 export 'src/unistd/unistd.dart';
 export 'src/wrapper.dart';

--- a/lib/src/uname/uname.dart
+++ b/lib/src/uname/uname.dart
@@ -1,0 +1,90 @@
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
+import 'package:ffi/ffi.dart' as ffi;
+import 'package:meta/meta.dart';
+
+import '../libc.dart';
+import '../posix_exception.dart';
+import '../unistd/errno.dart';
+import '../util/conversions.dart';
+
+part 'uname_bsd.dart';
+part 'uname_gnu.dart';
+
+/// Returns name and information about current kernel.
+Utsname uname() => ffi.using((arena) => Platform.isMacOS
+    ? _uname(arena<_utsname_bsd_t>()).toUtsname()
+    : _uname(arena<_utsname_gnu_t>()).toUtsname());
+
+/// Name and information about current kernel.
+@immutable
+class Utsname {
+  /// Constructs a new [Utsname] instance.
+  const Utsname({
+    required this.sysname,
+    required this.nodename,
+    required this.release,
+    required this.version,
+    required this.machine,
+  });
+
+  /// Operating system name (e.g., "Linux")
+  final String sysname;
+
+  /// Name within "some implementation-defined network"
+  final String nodename;
+
+  /// Operating system release (e.g., "2.6.28")
+  final String release;
+
+  /// Operating system version
+  final String version;
+
+  /// Hardware identifier
+  final String machine;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is Utsname &&
+        sysname == other.sysname &&
+        nodename == other.nodename &&
+        release == other.release &&
+        version == other.version &&
+        machine == other.machine;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        sysname,
+        nodename,
+        release,
+        version,
+        machine,
+      );
+
+  @override
+  String toString() =>
+      'Utsname(sysname: $sysname, nodename: $nodename, release: $release, '
+      'version: $version, machine: $machine)';
+}
+
+typedef _dart_uname = int Function(ffi.Pointer buf);
+// ignore: avoid_private_typedef_functions
+typedef _c_uname = ffi.Int32 Function(ffi.Pointer buf);
+
+// ignore: non_constant_identifier_names
+_dart_uname? _uname_f;
+
+ffi.Pointer<T> _uname<T extends ffi.NativeType>(ffi.Pointer<T> buf) {
+  _uname_f ??= Libc().dylib.lookupFunction<_c_uname, _dart_uname>('uname');
+
+  final res = _uname_f!(buf);
+  if (res != 0) {
+    throw PosixException('uname', errno());
+  }
+  return buf;
+}

--- a/lib/src/uname/uname_bsd.dart
+++ b/lib/src/uname/uname_bsd.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: constant_identifier_names
+
+part of 'uname.dart';
+
+const _UTSNAME_BSD_LENGTH = 256;
+
+class _utsname_bsd_t extends ffi.Struct {
+  @ffi.Array.multi([_UTSNAME_BSD_LENGTH])
+  external ffi.Array<ffi.Int8> sysname;
+
+  @ffi.Array.multi([_UTSNAME_BSD_LENGTH])
+  external ffi.Array<ffi.Int8> nodename;
+
+  @ffi.Array.multi([_UTSNAME_BSD_LENGTH])
+  external ffi.Array<ffi.Int8> release;
+
+  @ffi.Array.multi([_UTSNAME_BSD_LENGTH])
+  external ffi.Array<ffi.Int8> version;
+
+  @ffi.Array.multi([_UTSNAME_BSD_LENGTH])
+  external ffi.Array<ffi.Int8> machine;
+}
+
+extension _UtsnameBsd on ffi.Pointer<_utsname_bsd_t> {
+  Utsname toUtsname() => Utsname(
+        sysname: ref.sysname.toDartString(_UTSNAME_BSD_LENGTH),
+        nodename: ref.nodename.toDartString(_UTSNAME_BSD_LENGTH),
+        release: ref.release.toDartString(_UTSNAME_BSD_LENGTH),
+        version: ref.version.toDartString(_UTSNAME_BSD_LENGTH),
+        machine: ref.machine.toDartString(_UTSNAME_BSD_LENGTH),
+      );
+}

--- a/lib/src/uname/uname_gnu.dart
+++ b/lib/src/uname/uname_gnu.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: constant_identifier_names
+
+part of 'uname.dart';
+
+const _UTSNAME_GNU_LENGTH = 65;
+
+class _utsname_gnu_t extends ffi.Struct {
+  @ffi.Array.multi([_UTSNAME_GNU_LENGTH])
+  external ffi.Array<ffi.Int8> sysname;
+
+  @ffi.Array.multi([_UTSNAME_GNU_LENGTH])
+  external ffi.Array<ffi.Int8> nodename;
+
+  @ffi.Array.multi([_UTSNAME_GNU_LENGTH])
+  external ffi.Array<ffi.Int8> release;
+
+  @ffi.Array.multi([_UTSNAME_GNU_LENGTH])
+  external ffi.Array<ffi.Int8> version;
+
+  @ffi.Array.multi([_UTSNAME_GNU_LENGTH])
+  external ffi.Array<ffi.Int8> machine;
+}
+
+extension _UtsnameGnu on ffi.Pointer<_utsname_gnu_t> {
+  Utsname toUtsname() => Utsname(
+        sysname: ref.sysname.toDartString(_UTSNAME_GNU_LENGTH),
+        nodename: ref.nodename.toDartString(_UTSNAME_GNU_LENGTH),
+        release: ref.release.toDartString(_UTSNAME_GNU_LENGTH),
+        version: ref.version.toDartString(_UTSNAME_GNU_LENGTH),
+        machine: ref.machine.toDartString(_UTSNAME_GNU_LENGTH),
+      );
+}

--- a/lib/src/util/conversions.dart
+++ b/lib/src/util/conversions.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:ffi' as ffi;
 
 import 'package:ffi/ffi.dart' as pffi;
@@ -50,4 +51,18 @@ String copyCBuffToDartString<T extends ffi.NativeType>(ffi.Pointer<T> cBuf,
   }
 
   return string;
+}
+
+extension Utf8String on ffi.Array<ffi.Int8> {
+  String toDartString(int maxLength) {
+    final codeUnits = asTypedList(maxLength).takeWhile((c) => c != 0);
+    return utf8.decode(codeUnits.toList());
+  }
+}
+
+extension TypedInt8List on ffi.Array<ffi.Int8> {
+  // https://github.com/dart-lang/sdk/issues/45508
+  List<int> asTypedList(int length) => <int>[
+        for (var i = 0; i < length; ++i) this[i],
+      ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,9 +3,9 @@ version: 3.0.0
 homepage: https://github.com/bsutton/dart_posix
 description: Exposes the POSIX api on OSx and Linux
 environment: 
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 dependencies: 
-  ffi: ^1.0.0
+  ffi: ^1.1.2
   meta: ^1.7.0
   quiver: ^3.0.1+1
 dev_dependencies: 

--- a/test/src/uname_test.dart
+++ b/test/src/uname_test.dart
@@ -1,0 +1,15 @@
+import 'package:posix/src/uname/uname.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('uname', () async {
+    final utsname = uname();
+    print(utsname);
+
+    expect(utsname.sysname, isNotEmpty);
+    expect(utsname.nodename, isNotEmpty);
+    expect(utsname.release, isNotEmpty);
+    expect(utsname.version, isNotEmpty);
+    expect(utsname.machine, isNotEmpty);
+  });
+}


### PR DESCRIPTION
```dart
final utsname = uname();
print(utsname);
```

- [ubuntu-latest](https://github.com/jpnurmi/dart_posix/runs/5522812328)
  > Utsname(sysname: Linux, nodename: fv-az460-208, release: 5.11.0-1028-azure, version: #31~20.04.2-Ubuntu SMP Tue Jan 18 08:46:15 UTC 2022, machine: x86_64)

- [macos-latest](https://github.com/jpnurmi/dart_posix/runs/5522812345)
  > Utsname(sysname: Darwin, nodename: Mac-1647099649287.local, release: 20.6.0, version: Darwin Kernel Version 20.6.0: Wed Jan 12 22:22:42 PST 2022; root:xnu-7195.141.19~2/RELEASE_X86_64, machine: x86_64)

`Utsname.machine` helps to fix `lstat()` on M1/arm64 Macs where the `$INODE64` suffix should be dropped.